### PR TITLE
fix: Null errors on running

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -50,7 +50,7 @@
           <padding>
             <Insets top="10" right="10" bottom="10" left="10" />
           </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <StackPane fx:id="patientListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />

--- a/src/main/resources/view/PatientListPanel.fxml
+++ b/src/main/resources/view/PatientListPanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+  <ListView fx:id="patientListView" VBox.vgrow="ALWAYS" />
 </VBox>


### PR DESCRIPTION
Some \*person\* for JavaFx were not changed to patient, causing null errors on running AddressBook

NOTE: If you have an existing `data/addressbook.json`, delete the file else you will encounter errors loading the data inside