### PR TITLE
Fix bug where Important Dates were not saved to the AddressBook.json, and cannot be shown in `list` command

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedImportantDate.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedImportantDate.java
@@ -32,14 +32,6 @@ public class JsonAdaptedImportantDate {
         this.dateTime = convertToExpectedDateTimeFormat(source.importantDate, source.startTime, source.endTime);
     }
 
-    public String getName() {
-        return this.name;
-    }
-
-    public String getDateTime() {
-        return this.dateTime;
-    }
-
     /**
      * Converts this Jackson-friendly adapted tag object into the model's {@code ImportantDate} object.
      *

--- a/src/main/java/seedu/address/storage/JsonAdaptedImportantDate.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedImportantDate.java
@@ -1,0 +1,65 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.patient.ImportantDate;
+
+
+/**
+ * Jackson-friendly version of {@link ImportantDate}.
+ */
+public class JsonAdaptedImportantDate {
+    private final String name;
+    private final String dateTime;
+
+    /**
+     * Constructs a {@code JsonAdaptedImportantDate} with the given {@code eventName}, {@code dateTime}
+     */
+    @JsonCreator
+    public JsonAdaptedImportantDate(@JsonProperty("name") String name,
+                                    @JsonProperty("dateTime") String dateTime) {
+        this.name = name;
+        this.dateTime = dateTime;
+    }
+
+    /**
+     * Converts a given {@code ImportantDate} into this class for Jackson use.
+     */
+    public JsonAdaptedImportantDate(ImportantDate source) {
+        this.name = source.name;
+        this.dateTime = convertToExpectedDateTimeFormat(source.importantDate, source.startTime, source.endTime);
+    }
+
+//    @JsonValue
+    public String getName() {
+        return this.name;
+    }
+
+//    @JsonValue
+    public String getDateTime() {
+        return this.dateTime;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code ImportantDate} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted ImportantDate.
+     */
+    public ImportantDate toModelType() throws IllegalValueException {
+        if (!ImportantDate.isValidImportantDate(this.dateTime)) {
+            throw new IllegalValueException(ImportantDate.MESSAGE_CONSTRAINTS);
+        }
+        return new ImportantDate(this.name, this.dateTime);
+    }
+
+    private String convertToExpectedDateTimeFormat(String importantDate, String startTime, String endTime) {
+        if (startTime == null) {
+            return importantDate;
+        }
+
+        return String.format("%s, %s - %s", importantDate, startTime, endTime);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedImportantDate.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedImportantDate.java
@@ -1,9 +1,8 @@
 package seedu.address.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
+
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.patient.ImportantDate;
 
@@ -33,12 +32,10 @@ public class JsonAdaptedImportantDate {
         this.dateTime = convertToExpectedDateTimeFormat(source.importantDate, source.startTime, source.endTime);
     }
 
-//    @JsonValue
     public String getName() {
         return this.name;
     }
 
-//    @JsonValue
     public String getDateTime() {
         return this.dateTime;
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPatient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPatient.java
@@ -10,11 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.patient.Address;
-import seedu.address.model.patient.Email;
-import seedu.address.model.patient.Name;
-import seedu.address.model.patient.Patient;
-import seedu.address.model.patient.Phone;
+import seedu.address.model.patient.*;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -29,6 +25,7 @@ class JsonAdaptedPatient {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+    private final List<JsonAdaptedImportantDate> importantDates = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPatient} with the given patient details.
@@ -36,13 +33,17 @@ class JsonAdaptedPatient {
     @JsonCreator
     public JsonAdaptedPatient(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
                               @JsonProperty("email") String email, @JsonProperty("address") String address,
-                              @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+                              @JsonProperty("tags") List<JsonAdaptedTag> tags,
+                              @JsonProperty("importantDates") List<JsonAdaptedImportantDate> importantDates) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         if (tags != null) {
             this.tags.addAll(tags);
+        }
+        if (importantDates != null) {
+            this.importantDates.addAll(importantDates);
         }
     }
 
@@ -57,6 +58,9 @@ class JsonAdaptedPatient {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        importantDates.addAll(source.getImportantDates().stream()
+                .map(JsonAdaptedImportantDate::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -68,6 +72,11 @@ class JsonAdaptedPatient {
         final List<Tag> patientTags = new ArrayList<>();
         for (JsonAdaptedTag tag : tags) {
             patientTags.add(tag.toModelType());
+        }
+
+        final List<ImportantDate> patientImportantDates = new ArrayList<>();
+        for (JsonAdaptedImportantDate date : importantDates) {
+            patientImportantDates.add(date.toModelType());
         }
 
         if (name == null) {
@@ -103,7 +112,9 @@ class JsonAdaptedPatient {
         final Address modelAddress = new Address(address);
 
         final Set<Tag> modelTags = new HashSet<>(patientTags);
-        return new Patient(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+        final Set<ImportantDate> modelImportantDates = new HashSet<>(patientImportantDates);
+
+        return new Patient(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelImportantDates);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPatient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPatient.java
@@ -10,7 +10,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.patient.*;
+import seedu.address.model.patient.Address;
+import seedu.address.model.patient.Email;
+import seedu.address.model.patient.ImportantDate;
+import seedu.address.model.patient.Name;
+import seedu.address.model.patient.Patient;
+import seedu.address.model.patient.Phone;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/ui/PatientCard.java
+++ b/src/main/java/seedu/address/ui/PatientCard.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 
 import javafx.fxml.FXML;
@@ -7,6 +8,8 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import seedu.address.model.patient.ImportantDate;
 import seedu.address.model.patient.Patient;
 
 /**
@@ -41,7 +44,7 @@ public class PatientCard extends UiPart<Region> {
     @FXML
     private FlowPane tags;
     @FXML
-    private FlowPane importantDates;
+    private VBox importantDates;
 
     /**
      * Creates a {@code PatientCode} with the given {@code Patient} and index to display.
@@ -60,8 +63,12 @@ public class PatientCard extends UiPart<Region> {
 
         if (patient.getImportantDates().size() >= 1) {
             importantDates.getChildren().add(new Label("Upcoming:\n"));
-            patient.getImportantDates().stream()
-                    .forEach(importantDate -> importantDates.getChildren().add(new Label(importantDate.toString() + "\n")));
+
+            ArrayList<ImportantDate> allImportantDates = new ArrayList<>(patient.getImportantDates());
+            for (int i = 1; i <= allImportantDates.size(); i++) {
+                String currentImportantDate = allImportantDates.get(i - 1).toString();
+                importantDates.getChildren().add(new Label((i) + ". " + currentImportantDate + "\n"));
+            }
         }
     }
 }

--- a/src/main/java/seedu/address/ui/PatientCard.java
+++ b/src/main/java/seedu/address/ui/PatientCard.java
@@ -40,6 +40,8 @@ public class PatientCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane tags;
+    @FXML
+    private FlowPane importantDates;
 
     /**
      * Creates a {@code PatientCode} with the given {@code Patient} and index to display.
@@ -55,5 +57,7 @@ public class PatientCard extends UiPart<Region> {
         patient.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        patient.getImportantDates().stream()
+                .forEach(importantDate -> importantDates.getChildren().add(new Label(importantDate.toString())));
     }
 }

--- a/src/main/java/seedu/address/ui/PatientCard.java
+++ b/src/main/java/seedu/address/ui/PatientCard.java
@@ -52,32 +52,22 @@ public class PatientCard extends UiPart<Region> {
     public PatientCard(Patient patient, int displayedIndex) {
         super(FXML);
         this.patient = patient;
-
         id.setText(displayedIndex + ". ");
         name.setText(patient.getName().fullName);
         phone.setText(patient.getPhone().value);
         address.setText(patient.getAddress().value);
         email.setText(patient.getEmail().value);
-
-        this.displayTags(patient);
-        this.displayImportantDates(patient);
-    }
-
-    private void displayTags(Patient patient) {
         patient.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
 
-    }
-
-    private void displayImportantDates(Patient patient) {
         if (patient.getImportantDates().size() >= 1) {
             importantDates.getChildren().add(new Label("Upcoming:\n"));
 
             ArrayList<ImportantDate> allImportantDates = new ArrayList<>(patient.getImportantDates());
             for (int i = 1; i <= allImportantDates.size(); i++) {
-                String currentImportantDate = allImportantDates.get(i - 1).toString();
-                importantDates.getChildren().add(new Label((i) + ". " + currentImportantDate + "\n"));
+                importantDates.getChildren().add(new Label((i) + ". "
+                        + allImportantDates.get(i - 1).toString() + "\n"));
             }
         }
     }

--- a/src/main/java/seedu/address/ui/PatientCard.java
+++ b/src/main/java/seedu/address/ui/PatientCard.java
@@ -58,10 +58,10 @@ public class PatientCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
 
-        if (patient.getImportantDates().size() > 1) {
-            importantDates.getChildren().add(new Label("Upcoming:"));
+        if (patient.getImportantDates().size() >= 1) {
+            importantDates.getChildren().add(new Label("Upcoming:\n"));
             patient.getImportantDates().stream()
-                    .forEach(importantDate -> importantDates.getChildren().add(new Label(importantDate.toString())));
+                    .forEach(importantDate -> importantDates.getChildren().add(new Label(importantDate.toString() + "\n")));
         }
     }
 }

--- a/src/main/java/seedu/address/ui/PatientCard.java
+++ b/src/main/java/seedu/address/ui/PatientCard.java
@@ -57,7 +57,11 @@ public class PatientCard extends UiPart<Region> {
         patient.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-        patient.getImportantDates().stream()
-                .forEach(importantDate -> importantDates.getChildren().add(new Label(importantDate.toString())));
+
+        if (patient.getImportantDates().size() > 1) {
+            importantDates.getChildren().add(new Label("Upcoming:"));
+            patient.getImportantDates().stream()
+                    .forEach(importantDate -> importantDates.getChildren().add(new Label(importantDate.toString())));
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/PatientCard.java
+++ b/src/main/java/seedu/address/ui/PatientCard.java
@@ -52,15 +52,25 @@ public class PatientCard extends UiPart<Region> {
     public PatientCard(Patient patient, int displayedIndex) {
         super(FXML);
         this.patient = patient;
+
         id.setText(displayedIndex + ". ");
         name.setText(patient.getName().fullName);
         phone.setText(patient.getPhone().value);
         address.setText(patient.getAddress().value);
         email.setText(patient.getEmail().value);
+
+        this.displayTags(patient);
+        this.displayImportantDates(patient);
+    }
+
+    private void displayTags(Patient patient) {
         patient.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
 
+    }
+
+    private void displayImportantDates(Patient patient) {
         if (patient.getImportantDates().size() >= 1) {
             importantDates.getChildren().add(new Label("Upcoming:\n"));
 

--- a/src/main/resources/view/PatientListCard.fxml
+++ b/src/main/resources/view/PatientListCard.fxml
@@ -34,10 +34,6 @@
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
 
-    <FlowPane fx:id="importantDates" GridPane.columnIndex="1" alignment="CENTER_RIGHT" >
-      <padding>
-        <Insets top="0" right="50" bottom="0" left="0" />
-      </padding>
-    </FlowPane>
+    <VBox fx:id="importantDates" GridPane.columnIndex="1" alignment="CENTER" />
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PatientListCard.fxml
+++ b/src/main/resources/view/PatientListCard.fxml
@@ -31,6 +31,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <FlowPane fx:id="importantDates" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PatientListCard.fxml
+++ b/src/main/resources/view/PatientListCard.fxml
@@ -13,6 +13,7 @@
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
@@ -31,7 +32,12 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <FlowPane fx:id="importantDates" />
     </VBox>
+
+    <FlowPane fx:id="importantDates" GridPane.columnIndex="1" alignment="CENTER_RIGHT" >
+      <padding>
+        <Insets top="0" right="50" bottom="0" left="0" />
+      </padding>
+    </FlowPane>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPatientAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPatientAddressBook.json
@@ -5,42 +5,55 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "tags" : [ "friends" ]
+    "tags" : [ "friends" ],
+    "importantDates" : []
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "tags" : [ "owesMoney", "friends" ]
+    "tags" : [ "owesMoney", "friends" ],
+    "importantDates" : [ {
+      "name": "Birthday",
+      "dateTime": "20-02-2022"
+    }, {
+      "name": "Birthday",
+      "dateTime": "20-02-2022, 12:12 - 15:15"
+    } ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "tags" : [ ]
+    "tags" : [ ],
+    "importantDates" : []
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
-    "tags" : [ "friends" ]
+    "tags" : [ "friends" ],
+    "importantDates" : []
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
-    "tags" : [ ]
+    "tags" : [ ],
+    "importantDates" : []
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
-    "tags" : [ ]
+    "tags" : [ ],
+    "importantDates" : []
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
-    "tags" : [ ]
+    "tags" : [ ],
+    "importantDates" : []
   } ]
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPatientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPatientTest.java
@@ -12,7 +12,11 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.patient.*;
+import seedu.address.model.patient.Address;
+import seedu.address.model.patient.Email;
+import seedu.address.model.patient.Name;
+import seedu.address.model.patient.Phone;
+
 
 public class JsonAdaptedPatientTest {
     private static final String INVALID_NAME = "R@chel";
@@ -43,14 +47,16 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
+                new JsonAdaptedPatient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPatient person = new JsonAdaptedPatient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
+        JsonAdaptedPatient person = new JsonAdaptedPatient(null, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -58,14 +64,16 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
+                new JsonAdaptedPatient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
+        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, null, VALID_EMAIL,
+                VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -73,14 +81,16 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
+                        VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
+        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, null,
+                VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -88,14 +98,16 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
+                        VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_IMPORTANT_DATES);
+        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                null, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -105,16 +117,19 @@ public class JsonAdaptedPatientTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_IMPORTANT_DATES);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        invalidTags, VALID_IMPORTANT_DATES);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidDateTime_throwsIllegalValueException() {
         List<JsonAdaptedImportantDate> invalidImportantDates = new ArrayList<>(VALID_IMPORTANT_DATES);
-        invalidImportantDates.add(new JsonAdaptedImportantDate(VALID_IMPORTANT_DATETIME_NAME, INVALID_IMPORTANT_DATETIME_STR));
+        invalidImportantDates.add(new JsonAdaptedImportantDate(VALID_IMPORTANT_DATETIME_NAME,
+                INVALID_IMPORTANT_DATETIME_STR));
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, invalidImportantDates);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_TAGS, invalidImportantDates);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPatientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPatientTest.java
@@ -12,10 +12,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.patient.Address;
-import seedu.address.model.patient.Email;
-import seedu.address.model.patient.Name;
-import seedu.address.model.patient.Phone;
+import seedu.address.model.patient.*;
 
 public class JsonAdaptedPatientTest {
     private static final String INVALID_NAME = "R@chel";
@@ -23,6 +20,7 @@ public class JsonAdaptedPatientTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_IMPORTANT_DATETIME_STR = "Something";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -30,6 +28,10 @@ public class JsonAdaptedPatientTest {
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
+            .collect(Collectors.toList());
+    private static final String VALID_IMPORTANT_DATETIME_NAME = "Birthday";
+    private static final List<JsonAdaptedImportantDate> VALID_IMPORTANT_DATES = BENSON.getImportantDates().stream()
+            .map(JsonAdaptedImportantDate::new)
             .collect(Collectors.toList());
 
     @Test
@@ -41,14 +43,14 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPatient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPatient person = new JsonAdaptedPatient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPatient person = new JsonAdaptedPatient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -56,14 +58,14 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPatient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -71,14 +73,14 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,14 +88,14 @@ public class JsonAdaptedPatientTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPatient person = new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_IMPORTANT_DATES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,8 +105,16 @@ public class JsonAdaptedPatientTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPatient person =
-                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_IMPORTANT_DATES);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
+    @Test
+    public void toModelType_invalidDateTime_throwsIllegalValueException() {
+        List<JsonAdaptedImportantDate> invalidImportantDates = new ArrayList<>(VALID_IMPORTANT_DATES);
+        invalidImportantDates.add(new JsonAdaptedImportantDate(VALID_IMPORTANT_DATETIME_NAME, INVALID_IMPORTANT_DATETIME_STR));
+        JsonAdaptedPatient person =
+                new JsonAdaptedPatient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, invalidImportantDates);
+        assertThrows(IllegalValueException.class, person::toModelType);
+    }
 }

--- a/src/test/java/seedu/address/testutil/PatientBuilder.java
+++ b/src/test/java/seedu/address/testutil/PatientBuilder.java
@@ -107,7 +107,7 @@ public class PatientBuilder {
     }
 
     public Patient build() {
-        return new Patient(name, phone, email, address, tags);
+        return new Patient(name, phone, email, address, tags, importantDates);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPatients.java
+++ b/src/test/java/seedu/address/testutil/TypicalPatients.java
@@ -1,13 +1,25 @@
 package seedu.address.testutil;
 
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_IMPORTANT_DATE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_IMPORTANT_DATETIME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_IMPORTANT_DATE_NAME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.patient.Patient;
-
-import static seedu.address.logic.commands.CommandTestUtil.*;
 
 
 /**

--- a/src/test/java/seedu/address/testutil/TypicalPatients.java
+++ b/src/test/java/seedu/address/testutil/TypicalPatients.java
@@ -1,22 +1,14 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.patient.Patient;
+
+import static seedu.address.logic.commands.CommandTestUtil.*;
+
 
 /**
  * A utility class containing a list of {@code Patient} objects to be used in tests.
@@ -30,7 +22,9 @@ public class TypicalPatients {
     public static final Patient BENSON = new PatientBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withTags("owesMoney", "friends").withImportantDates(
+                    new String[] { VALID_IMPORTANT_DATE_NAME, VALID_IMPORTANT_DATE_NAME },
+                    new String[] { VALID_IMPORTANT_DATE, VALID_IMPORTANT_DATETIME }).build();
     public static final Patient CARL = new PatientBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Patient DANIEL = new PatientBuilder().withName("Daniel Meier").withPhone("87652533")


### PR DESCRIPTION
Closes #64.

The original issue was that Important Dates for Users could not be seen in the `list` command. 

This PR fixes that, as well as a related issue whereby Important Dates were not stored properly in `addressbook.json`, resulting in them being reset each time PatientSync is run.

Related: #60, #6 