### PR TITLE
Preserve Ordering for Events by Sorting them

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -626,6 +626,8 @@ The `ListCommand` is responsible for listing all patients in the address book.
 causing the UI to only show all patients.
 * The UML sequence diagram below shows the interaction between the Logic and Model components after calling `list`
 command.
+* For each Patient's Events, the Events will be displayed in ascending order by date, then start time if date is equal, 
+then end time if both date and start time is equal
 
 <puml src="diagrams/ListSequenceDiagram.puml" alt="List Sequence Diagram" />
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -800,21 +800,21 @@ PatientSync is meticulously crafted for nurses who prioritize the well-being of 
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
-| Priority | As a …​                                    | I want to …​                                               | So that I can…​                                                                                                                         |
-|----------|--------------------------------------------|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `***`    | Nurse                                      | easily view the user guide                                 | learn more about the product and how to use whenever I need to                                                                          |
-| `***`    | Nurse                                      | add patient's information                                  | add new patients and easily remember their preferences to make a personalized connection                                                |
-| `***`    | Nurse                                      | delete patient's information                               | remove patients who have been discharged                                                                                                |
-| `***`    | Nurse                                      | list all patient's information                             | easily find the details of my patients                                                                                                  |
-| `***`    | Nurse                                      | add important dates for my patients                       | keep track of my patients' appointments and see my overall schedule                                                                     |
-| `***`    | Nurse                                      | delete important dates for my patients                    | delete my patients' appointments if they are canceled                                                                                   |
-| `***`    | Nurse                                      | add tags to my patients                                    | group the patients into categories                                                                                                      |
-| `***`    | Nurse                                      | find patient with a specific tag                            | quickly locate individuals with similar conditions, treatments, or requirements without having to scroll through the entire patient list |
-| `***`    | Nurse                                      | save all previously added patients                         | ensure details of the patient would not be lost                                                                                         |
-| `**`     | Nurse                                      | edit patient's information                                 | have the most updated information of my patients at all times                                                                           |
-| `**`     | Nurse                                      | edit important dates for my patients                      | edit my patients' appointments if they are changed                                                                                      |
-| `**`     | Nurse                                      | edit tags from my patients                                 | edit mistyped tags                                                                                         |
-| `**`     | Nurse                                      | delete tags from my patients                               | delete the tag if it no longer applies                                                                                                  |
+| Priority | As a …​                                    | I want to …​                       | So that I can…​                                                                                                                         |
+|----------|--------------------------------------------|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `***`    | Nurse                                      | easily view the user guide         | learn more about the product and how to use whenever I need to                                                                          |
+| `***`    | Nurse                                      | add patient's information          | add new patients and easily remember their preferences to make a personalized connection                                                |
+| `***`    | Nurse                                      | delete patient's information       | remove patients who have been discharged                                                                                                |
+| `***`    | Nurse                                      | list all patient's information     | easily find the details of my patients                                                                                                  |
+| `***`    | Nurse                                      | add event for my patients          | keep track of my patients' appointments and see my overall schedule                                                                     |
+| `***`    | Nurse                                      | delete event for my patients       | delete my patients' appointments if they are canceled                                                                                   |
+| `***`    | Nurse                                      | add tags to my patients            | group the patients into categories                                                                                                      |
+| `***`    | Nurse                                      | find patient with a specific tag   | quickly locate individuals with similar conditions, treatments, or requirements without having to scroll through the entire patient list |
+| `***`    | Nurse                                      | save all previously added patients | ensure details of the patient would not be lost                                                                                         |
+| `**`     | Nurse                                      | edit patient's information         | have the most updated information of my patients at all times                                                                           |
+| `**`     | Nurse                                      | edit event for my patients          | edit my patients' appointments if they are changed                                                                                      |
+| `**`     | Nurse                                      | edit tags from my patients         | edit mistyped tags                                                                                         |
+| `**`     | Nurse                                      | delete tags from my patients       | delete the tag if it no longer applies                                                                                                  |
 
 
 
@@ -877,14 +877,14 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
   Use case ends.
 
-**Use case: Add important date for a patient**
+**Use case: Add event for a patient**
 
 **MSS**
 
 1.  Nurse requests to list patients
 2.  PatientSync shows a list of patients
-3.  Nurse requests to add an important date for a specific patient in the list
-4.  PatientSync adds an important date for the patient
+3.  Nurse requests to add an event for a specific patient in the list
+4.  PatientSync adds an event for the patient
 
     Use case ends.
 
@@ -900,14 +900,14 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes at step 2.
 
-**Use case: Delete an important date for a patient**
+**Use case: Delete an event for a patient**
 
 **MSS**
 
 1.  Nurse requests to list patients
 2.  PatientSync shows a list of patients
-3.  Nurse requests to delete an important date for a specific patient in the list
-4.  PatientSync deletes an important date the patient
+3.  Nurse requests to delete an event for a specific patient in the list
+4.  PatientSync deletes an event the patient
 
     Use case ends.
 

--- a/src/main/java/seedu/address/logic/commands/AddEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEventCommand.java
@@ -20,13 +20,13 @@ import seedu.address.model.patient.Event;
 import seedu.address.model.patient.Patient;
 
 /**
- * Adds an important date to the specified patient (based on index from the last shown patient list)
+ * Adds an event to the specified patient (based on index from the last shown patient list)
  */
 public class AddEventCommand extends Command {
     public static final String COMMAND_WORD = "adde";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds an Important Date for a Patient. "
+            + ": Adds an event for a Patient. "
             + "Parameters: INDEX (must be a positive integer matching that of the Patient in the `list` command) "
             + PREFIX_NAME + " [Name of the Event that falls on this Date] "
             + PREFIX_DATETIME + " [Date / Datetime, in the format DD-MM-YYYY"
@@ -89,10 +89,10 @@ public class AddEventCommand extends Command {
     }
 
     /**
-     * Returns true if both add important date commands have the same index and important date to add.
+     * Returns true if both AddEventCommands have the same index and important date to add.
      *
      * @param other Another object to compare to.
-     * @return True if the other object is an AddEventCommand with the same index and important date to add.
+     * @return True if the other object is an AddEventCommand with the same index and date / datetime to add.
      */
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.EditCommand.createEditedPatient;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PATIENTS;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -78,9 +79,12 @@ public class DeleteEventCommand extends Command {
 
         Set<Event> currEventSet = new HashSet<>(patientToDeleteEvent.getEvents());
         List<Event> currEventList = new ArrayList<>(currEventSet);
+        Collections.sort(currEventList);
+
         Event eventToDelete = currEventList.get(targetEventIndex.getZeroBased());
         currEventList.remove(targetEventIndex.getZeroBased());
         Set<Event> newEventSet = new HashSet<>(currEventList);
+
         Logger logger = LogsCenter.getLogger(DeleteEventCommandParser.class);
         logger.log(Level.INFO, "old set: " + currEventSet);
         logger.log(Level.INFO, "new set: " + newEventSet);

--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -32,7 +32,7 @@ public class DeleteEventCommand extends Command {
     public static final String COMMAND_WORD = "deletee";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes a specified important date event for a specific patient identified by index number of patient "
+            + ": Deletes a specified event for a specific patient identified by index number of patient "
             + " in the displayed patient list as well as the event index.\n"
             + "Parameters: INDEX of PATIENT (must be a positive integer matching that of the Patient in the"
             + "`list` command) "

--- a/src/main/java/seedu/address/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PATIENTS;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -80,6 +81,8 @@ public class EditEventCommand extends Command {
         }
 
         List<Event> eventList = new ArrayList<>(events);
+        Collections.sort(eventList);
+
         eventList.set(eventIndex.getZeroBased(), eventToUpdate);
         Set<Event> updatedEvents = new HashSet<>(eventList);
         editPatientDescriptor.setEvents(updatedEvents);

--- a/src/main/java/seedu/address/model/patient/Event.java
+++ b/src/main/java/seedu/address/model/patient/Event.java
@@ -133,14 +133,13 @@ public class Event implements Comparable<Event> {
             if (!this.endTime.equals(other.endTime)) {
                 return this.endTime.compareTo(other.endTime);
             }
-        } else {
-            // If only 1 event has time information, that event should be sorted behind
-            if (this.startTime != null && other.startTime == null) {
-                return 1;
-            }
-            if (this.startTime == null && other.startTime != null) {
-                return -1;
-            }
+        }
+        // If only 1 event has time information, that event should be sorted behind
+        if (this.startTime != null && other.startTime == null) {
+            return 1;
+        }
+        if (this.startTime == null && other.startTime != null) {
+            return -1;
         }
 
         // If all date / datetime information is the same, sort by name

--- a/src/main/java/seedu/address/model/patient/Event.java
+++ b/src/main/java/seedu/address/model/patient/Event.java
@@ -120,15 +120,31 @@ public class Event implements Comparable<Event> {
 
     @Override
     public int compareTo(Event other) {
-        if (this.date.equals(other.date)) {
-            if (this.startTime.equals(other.startTime)) {
-                return this.endTime.compareTo(other.endTime);
-            }
-
-            return this.startTime.compareTo(other.startTime);
+        if (!this.date.equals(other.date)) {
+            return this.date.compareTo(other.date);
         }
 
-        return this.date.compareTo(other.date);
+        if (this.startTime != null && other.startTime != null) {
+            // If both events have time information, sort by start time then end time
+            if (!this.startTime.equals(other.startTime)) {
+                return this.startTime.compareTo(other.startTime);
+            }
+
+            if (!this.endTime.equals(other.endTime)) {
+                return this.endTime.compareTo(other.endTime);
+            }
+        } else {
+            // If only 1 event has time information, that event should be sorted behind
+            if (this.startTime != null && other.startTime == null) {
+                return 1;
+            }
+            if (this.startTime == null && other.startTime != null) {
+                return -1;
+            }
+        }
+
+        // If all date / datetime information is the same, sort by name
+        return this.name.compareTo(other.name);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/patient/Event.java
+++ b/src/main/java/seedu/address/model/patient/Event.java
@@ -11,7 +11,7 @@ import java.time.format.DateTimeParseException;
 /**
  * Represents Important Dates for a Patient
  */
-public class Event {
+public class Event implements Comparable<Event> {
     public static final String MESSAGE_CONSTRAINTS =
             "Dates should be in the format: DD-MM-YYYY, HH:mm - HH:mm, OR if there is no time period,"
             + "in the format: DD-MM-YYYY";
@@ -117,6 +117,19 @@ public class Event {
         return new String[] {args[0], temp[0], temp[1]};
     }
 
+
+    @Override
+    public int compareTo(Event other) {
+        if (this.date == other.date) {
+            if (this.startTime == other.startTime) {
+                return this.endTime.compareTo(other.endTime);
+            }
+
+            return this.startTime.compareTo(other.startTime);
+        }
+
+        return this.date.compareTo(other.date);
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/patient/Event.java
+++ b/src/main/java/seedu/address/model/patient/Event.java
@@ -120,8 +120,8 @@ public class Event implements Comparable<Event> {
 
     @Override
     public int compareTo(Event other) {
-        if (this.date == other.date) {
-            if (this.startTime == other.startTime) {
+        if (this.date.equals(other.date)) {
+            if (this.startTime.equals(other.startTime)) {
                 return this.endTime.compareTo(other.endTime);
             }
 

--- a/src/main/java/seedu/address/ui/PatientCard.java
+++ b/src/main/java/seedu/address/ui/PatientCard.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 
 import javafx.fxml.FXML;
@@ -70,6 +71,7 @@ public class PatientCard extends UiPart<Region> {
             events.getChildren().add(new Label("Upcoming:\n"));
 
             ArrayList<Event> allEvents = new ArrayList<>(patient.getEvents());
+            Collections.sort(allEvents);
             for (int i = 1; i <= allEvents.size(); i++) {
                 events.getChildren().add(new Label((i) + ". "
                         + allEvents.get(i - 1).toString() + "\n"));

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -70,10 +70,6 @@ public class CommandTestUtil {
     public static final String HOBBY_DESC_BOB = " " + PREFIX_HOBBY + VALID_HOBBY_BOB;
     public static final String TAG_DESC_DIABETES = " " + PREFIX_TAG + VALID_TAG_DIABETES;
     public static final String TAG_DESC_DEPRESSION = " " + PREFIX_TAG + VALID_TAG_DEPRESSION;
-    public static final String IMPORTANT_DATE_DESC_DATE = " " + PREFIX_NAME + VALID_EVENT_NAME + " "
-        + PREFIX_DATETIME + VALID_EVENT_DATE;
-    public static final String IMPORTANT_DATE_DESC_DATETIME = " " + PREFIX_NAME + VALID_EVENT_NAME + " "
-        + PREFIX_DATETIME + VALID_EVENT_DATETIME;
 
     public static final String INVALID_ID_DESC = " " + PREFIX_PID + "10 a"; // only digits are allowed in ID
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James& Lee Kuang"; // '&' not allowed in names
@@ -87,8 +83,6 @@ public class CommandTestUtil {
     public static final String INVALID_HOBBY_DESC = " " + PREFIX_HOBBY;
     // '*' and spacing not allowed in tags
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hearing loss*";
-    public static final String INVALID_IMPORTANT_DATE_DESC = " " + PREFIX_NAME + VALID_EVENT_NAME
-        + PREFIX_DATETIME + "Invalid";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/model/patient/EventTest.java
+++ b/src/test/java/seedu/address/model/patient/EventTest.java
@@ -57,12 +57,16 @@ public class EventTest {
     @Test
     public void compareTo() {
         Event earlierEvent = new Event("Family Visit", "01-01-2022, 12:12 - 12:12");
+        Event nullTimeEvent = new Event("Family Visit", "01-01-2022");
         Event laterDateEvent = new Event("Family Visit", "02-01-2022, 12:12 - 12:12");
         Event laterMonthEvent = new Event("Family Visit", "01-02-2022, 12:12 - 12:12");
         Event laterYearEvent = new Event("Family Visit", "01-01-2023, 12:12 - 12:12");
         Event laterStartTimeEvent = new Event("Family Visit", "01-01-2022, 12:13 - 12:12");
         Event laterEndTimeEvent = new Event("Family Visit", "01-01-2022, 12:12 - 12:13");
         Event laterNameEvent = new Event("Z", "01-01-2022, 12:12 - 12:12");
+
+        assertTrue(earlierEvent.compareTo(nullTimeEvent) > 0);
+        assertTrue(nullTimeEvent.compareTo(earlierEvent) < 0);
 
         assertTrue(earlierEvent.compareTo(laterDateEvent) < 0);
         assertTrue(laterDateEvent.compareTo(earlierEvent) > 0);

--- a/src/test/java/seedu/address/model/patient/EventTest.java
+++ b/src/test/java/seedu/address/model/patient/EventTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.patient;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -51,6 +52,32 @@ public class EventTest {
         assertTrue(Event.isValidEvent("21-02-2022, 00:00 - 23:59"));
         assertTrue(Event.isValidEvent("01-01-2022, 12:12 - 12:12        "));
         assertTrue(Event.isValidEvent("          01-01-2022, 12:12 - 12:12"));
+    }
+
+
+    @Test
+    public void compareTo() {
+        Event earlierEvent = new Event("Family Visit", "01-01-2022, 12:12 - 12:12");
+        Event laterDateEvent = new Event("Family Visit", "02-01-2022, 12:12 - 12:12");
+        Event laterMonthEvent = new Event("Family Visit", "01-02-2022, 12:12 - 12:12");
+        Event laterYearEvent = new Event("Family Visit", "01-01-2023, 12:12 - 12:12");
+        Event laterStartTimeEvent = new Event("Family Visit", "01-01-2022, 12:13 - 12:12");
+        Event laterEndTimeEvent = new Event("Family Visit", "01-01-2022, 12:12 - 12:13");
+
+        assertEquals(earlierEvent.compareTo(laterDateEvent), -1);
+        assertEquals(laterDateEvent.compareTo(earlierEvent), 1);
+
+        assertEquals(earlierEvent.compareTo(laterMonthEvent), -1);
+        assertEquals(laterMonthEvent.compareTo(earlierEvent), 1);
+
+        assertEquals(earlierEvent.compareTo(laterYearEvent), -1);
+        assertEquals(laterYearEvent.compareTo(earlierEvent), 1);
+
+        assertEquals(earlierEvent.compareTo(laterStartTimeEvent), -1);
+        assertEquals(laterStartTimeEvent.compareTo(earlierEvent), 1);
+
+        assertEquals(earlierEvent.compareTo(laterEndTimeEvent), -1);
+        assertEquals(laterEndTimeEvent.compareTo(earlierEvent), 1);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/patient/EventTest.java
+++ b/src/test/java/seedu/address/model/patient/EventTest.java
@@ -1,6 +1,5 @@
 package seedu.address.model.patient;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -63,21 +62,25 @@ public class EventTest {
         Event laterYearEvent = new Event("Family Visit", "01-01-2023, 12:12 - 12:12");
         Event laterStartTimeEvent = new Event("Family Visit", "01-01-2022, 12:13 - 12:12");
         Event laterEndTimeEvent = new Event("Family Visit", "01-01-2022, 12:12 - 12:13");
+        Event laterNameEvent = new Event("Z", "01-01-2022, 12:12 - 12:12");
 
-        assertEquals(earlierEvent.compareTo(laterDateEvent), -1);
-        assertEquals(laterDateEvent.compareTo(earlierEvent), 1);
+        assertTrue(earlierEvent.compareTo(laterDateEvent) < 0);
+        assertTrue(laterDateEvent.compareTo(earlierEvent) > 0);
 
-        assertEquals(earlierEvent.compareTo(laterMonthEvent), -1);
-        assertEquals(laterMonthEvent.compareTo(earlierEvent), 1);
+        assertTrue(earlierEvent.compareTo(laterMonthEvent) < 0);
+        assertTrue(laterMonthEvent.compareTo(earlierEvent) > 0);
 
-        assertEquals(earlierEvent.compareTo(laterYearEvent), -1);
-        assertEquals(laterYearEvent.compareTo(earlierEvent), 1);
+        assertTrue(earlierEvent.compareTo(laterYearEvent) < 0);
+        assertTrue(laterYearEvent.compareTo(earlierEvent) > 0);
 
-        assertEquals(earlierEvent.compareTo(laterStartTimeEvent), -1);
-        assertEquals(laterStartTimeEvent.compareTo(earlierEvent), 1);
+        assertTrue(earlierEvent.compareTo(laterStartTimeEvent) < 0);
+        assertTrue(laterStartTimeEvent.compareTo(earlierEvent) > 0);
 
-        assertEquals(earlierEvent.compareTo(laterEndTimeEvent), -1);
-        assertEquals(laterEndTimeEvent.compareTo(earlierEvent), 1);
+        assertTrue(earlierEvent.compareTo(laterEndTimeEvent) < 0);
+        assertTrue(laterEndTimeEvent.compareTo(earlierEvent) > 0);
+
+        assertTrue(earlierEvent.compareTo(laterNameEvent) < 0);
+        assertTrue(laterNameEvent.compareTo(earlierEvent) > 0);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PatientBuilder.java
+++ b/src/test/java/seedu/address/testutil/PatientBuilder.java
@@ -123,7 +123,7 @@ public class PatientBuilder {
      * Sets the Event of the {@code Patient} that we are building,
      * with the name and date/datetime of the event
      *
-     * @param names description of important date
+     * @param names description of events
      * @param events array of string of dates
      * @return return PatientBuilder withImportantDates
      */


### PR DESCRIPTION
Changes Made:
- Sort Events whenever editing, deleting or reading them, to preserve the correct ordering of Events by date, then start time, then end time
- Update DG
- Remove remaining "Important Date" in comments / docs, and rename to "Event"

Closes #81.