### PR TITLE
Update message delete event success to match with edit event

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -41,8 +41,8 @@ public class DeleteEventCommand extends Command {
             + COMMAND_WORD + " 1 "
             + "e/ 1 ";
 
-    public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Event %1$s successfully deleted for Patient %2$s with"
-            + " ID %3$s for %4$s";
+    public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Event %1$s with ID %2$s on %3$s successfully deleted "
+            + "for Patient %4$s with ID %5$s";
 
     private final Index targetPatientIndex;
     private final Index targetEventIndex;
@@ -104,7 +104,8 @@ public class DeleteEventCommand extends Command {
         model.setPatient(patientToDeleteEvent, editedPatient);
         model.updateFilteredPatientList(PREDICATE_SHOW_ALL_PATIENTS);
         return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS, eventToDelete.name,
-                patientToDeleteEvent.getName(), targetEventIndex.getOneBased(), eventToDelete.date));
+                targetEventIndex.getOneBased(), eventToDelete.date, patientToDeleteEvent.getName(),
+                targetPatientIndex.getOneBased()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -41,8 +41,8 @@ public class DeleteEventCommand extends Command {
             + COMMAND_WORD + " 1 "
             + "e/ 1 ";
 
-    public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Deleted Event: %2$s for Patient: %1$s"
-            + "successfully";
+    public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Event %1$s successfully deleted for Patient %2$s with"
+            + " ID %3$s for %4$s";
 
     private final Index targetPatientIndex;
     private final Index targetEventIndex;
@@ -103,9 +103,8 @@ public class DeleteEventCommand extends Command {
         Patient editedPatient = createEditedPatient(patientToDeleteEvent, editPatientDescriptor);
         model.setPatient(patientToDeleteEvent, editedPatient);
         model.updateFilteredPatientList(PREDICATE_SHOW_ALL_PATIENTS);
-        return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS,
-                Messages.format(patientToDeleteEvent),
-                eventToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_EVENT_SUCCESS, eventToDelete.name,
+                patientToDeleteEvent.getName(), targetEventIndex.getOneBased(), eventToDelete.date));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
@@ -82,7 +82,8 @@ public class DeleteEventCommandTest {
         Event eventToDelete = currEventList.get(INDEX_FIRST_EVENT.getZeroBased());
         CommandResult result = deleteEventCommand.execute(model);
         String expected = String.format(String.format(MESSAGE_DELETE_EVENT_SUCCESS, eventToDelete.name,
-                editedPatient.getName(), INDEX_FIRST_EVENT.getOneBased(), eventToDelete.date));
+                INDEX_FIRST_EVENT.getOneBased(), eventToDelete.date, editedPatient.getName(),
+                validIndex.getOneBased()));
         assertEquals(expected, result.getFeedbackToUser());
 
         Set<Event> expectedEvents = new HashSet<>(editedPatient.getEvents());

--- a/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteEventCommandTest.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -82,9 +81,8 @@ public class DeleteEventCommandTest {
         List<Event> currEventList = new ArrayList<>(editedPatient.getEvents());
         Event eventToDelete = currEventList.get(INDEX_FIRST_EVENT.getZeroBased());
         CommandResult result = deleteEventCommand.execute(model);
-        String expected = String.format(MESSAGE_DELETE_EVENT_SUCCESS,
-                Messages.format(editedPatient),
-                eventToDelete);
+        String expected = String.format(String.format(MESSAGE_DELETE_EVENT_SUCCESS, eventToDelete.name,
+                editedPatient.getName(), INDEX_FIRST_EVENT.getOneBased(), eventToDelete.date));
         assertEquals(expected, result.getFeedbackToUser());
 
         Set<Event> expectedEvents = new HashSet<>(editedPatient.getEvents());


### PR DESCRIPTION
 This commit updates the delete event success message to match with the edit event success message for consistency.
- Corresponding test case in DeleteEventCommandSuccess has been updated as well

Fixes #101 