### PR TITLE
Update regex expression for patient's Name

### DIFF
--- a/src/main/java/seedu/address/model/patient/Name.java
+++ b/src/main/java/seedu/address/model/patient/Name.java
@@ -10,13 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+        "Names should only contain alphanumeric characters, dashes (-), periods (.), commas (,), and slashes (/), "
+            + "and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[-\\p{Alnum},./][\\p{Alnum},./ -]*";
 
     public final String fullName;
 

--- a/src/test/java/seedu/address/model/patient/NameTest.java
+++ b/src/test/java/seedu/address/model/patient/NameTest.java
@@ -29,6 +29,7 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("johnson?")); // contains non-alphanumeric characters
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
@@ -36,6 +37,10 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("Abraham s/o Ahmad")); // names with s/o
+        assertTrue(Name.isValidName("Joseph-Damson")); // names with dashes
+        assertTrue(Name.isValidName("Gorge, William")); // names with commas
+        assertTrue(Name.isValidName("Benson St. Kaisa")); // names with periods
     }
 
     @Test


### PR DESCRIPTION
This commits enhance the regex expression validation for patient's Name, such that it accounts for names with:

- periods (eg. William St. Karl) 
- comma (eg. Josheph, Ben) 
- slash (eg. Katherine d/o Rashul) 

Fixes #122 