### PR TITLE
v1.3 Update UserGuide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -156,8 +156,8 @@ e.g. `Alex` will not match `Alexandra`, `Alex` will match `Alex Becker`
 e.g. `Alex Becker` will return `Alex Keller` and `Becker Anderson`
 
 Examples:
-* find `Alex` returns `alex` and `Alex becker`
-* find `alex becker` returns `alex`, `Alex Becker` and `Becker Li`
+* `find Alex` returns `alex` and `Alex becker`
+* `find alex becker` returns `alex`, `Alex Becker` and `Becker Li`
 
 ![result for 'find patients whose name is alex becker'](images/findPatientAlexBeckerResult.png)
 
@@ -251,8 +251,8 @@ Format: `findt KEYWORD [MORE_KEYWORDS]`
   e.g. `depression diabetes` will return `depression wheelchair` and `diabetes tumour`
 
 Examples:
-* find `depression` returns `depression` and `depression diabetes`
-* find `depression diabetes` returns `depression`, `depression diabetes` and `diabetes wheelchair`
+* `findt depression` returns `depression` and `depression diabetes`
+* `findt depression diabetes` returns `depression`, `depression diabetes` and `diabetes wheelchair`
 
 ![result for 'find tags'](images/findTagsResult.png)
 
@@ -262,7 +262,7 @@ Examples:
 
 Adds an Event to a patient in the address book.
 
-Format: `adde INDEX [n/NAME_OF_EVENT_ON_THAT_DATE] [d/DATE_OR_DATETIME_OF_EVENT_ON_THAT_DATE]`
+Format: `adde INDEX n/NAME_OF_EVENT_ON_THAT_DATE d/DATE_OR_DATETIME_OF_EVENT_ON_THAT_DATE`
 
 * Adds an Event with a Name, as well as the Date and optionally, the Time Period for which the Event is happening on that date to a patient identified by the index number used in the last patient listing.
 * The index **must be a positive integer** 1, 2, 3, ...
@@ -284,7 +284,7 @@ Examples:
 
 Deletes an Event from a patient in the address book.
 
-Format `deletee PATIENT_INDEX [e/EVENT_INDEX]`
+Format `deletee PATIENT_INDEX e/EVENT_INDEX`
 
 * Deletes an Event from a specified Patient using `PATIENT_INDEX` and `EVENT_INDEX`.
 * `PATIENT_INDEX` is the index of the patient shown in the UI after using `list` or `find` command.
@@ -306,7 +306,7 @@ Examples:
 
 Edits an Event for a Patient in the address book.
 
-Format `edite PATIENT_INDEX [e/EVENT_INDEX] [n/NAME_OF_EVENT_ON_THAT_DATE] [d/DATE_OR_DATETIME_OF_EVENT_ON_THAT_DATE]`
+Format `edite PATIENT_INDEX e/EVENT_INDEX n/NAME_OF_EVENT_ON_THAT_DATE d/DATE_OR_DATETIME_OF_EVENT_ON_THAT_DATE`
 
 * Edits an Event for a Patient using `PATIENT_INDEX`, `EVENT_INDEX`, `NAME_OF_EVENT_ON_THAT_DATE` and
   `DATE_OR_DATETIME_OF_EVENT_ON_THAT_DATE`.
@@ -418,9 +418,9 @@ Action     | Format, Examples
 **Add Tags**   | `addt INDEX [t/TAG]+`<br> e.g. `addt 1 t/critical`
 **Delete Tags**   | `deletet INDEX [t/TAG]+`<br> e.g. `deletet 1 t/critical`
 **Find Tags**   | `findt KEYWORD [MORE_KEYWORDS]`<br> e.g. `findt depression diabetes`
-**AddEvent** | `adde INDEX [n/NAME_OF_EVENT_ON_THAT_DATE] [d/DATE_OR_DATETIME_OF_EVENT_ON_THAT_DATE]` <br> e.g. `adde 1 n/Birthday d/20-01-2022`
-**DeleteEvent** | `deletee PATIENT_INDEX [e/EVENT_INDEX]` <br> e.g. `deletee 1 e/1`
-**EditEvent** | `edite PATIENT_INDEX [e/EVENT_INDEX] [n/NAME_OF_EVENT_ON_THAT_DATE] [d/DATE_OR_DATETIME_OF_EVENT_ON_THAT_DATE]` <br> e.g. `edite 1 e/1 n/Papa Birthday d/20-01-2023`
+**Add Event** | `adde INDEX n/NAME_OF_EVENT_ON_THAT_DATE d/DATE_OR_DATETIME_OF_EVENT_ON_THAT_DATE` <br> e.g. `adde 1 n/Birthday d/20-01-2022`
+**Delete Event** | `deletee PATIENT_INDEX e/EVENT_INDEX` <br> e.g. `deletee 1 e/1`
+**Edit Event** | `edite PATIENT_INDEX e/EVENT_INDEX n/NAME_OF_EVENT_ON_THAT_DATE d/DATE_OR_DATETIME_OF_EVENT_ON_THAT_DATE` <br> e.g. `edite 1 e/1 n/Papa Birthday d/20-01-2023`
 **Sort** | `sort [ATTRIBUTE]` <br> e.g. `sort p`
 **List**   | `list`
 **Help**   | `help`


### PR DESCRIPTION
User Guide now show a better example for FindCommand and FindTagsCommand.
Also, square brackets in all event commands are removed because all prefix are compulsory.

Fix #166 