### PR TITLE
Docs: Update typo error in sort command specifications in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -434,7 +434,7 @@ Format: `sort [ATTRIBUTE]`
 * Supported `ATTRIBUTE`s include `n` for patient name and `p` for patient's preferred name.
 * There can only be one or zero `ATTRIBUTE`.
 * If no `ATTRIBUTE` is specified, default sorting order would be by patient's name.
-* `ATTRIBUTES` are **case-insensitive**.
+* `ATTRIBUTE`s are **case-insensitive**.
 * The command will not be recognised if invalid `ATTRIBUTE`(s) are entered. e.g. `sort l` or `sort 123` are invalid
 sort commands.
 * If there are multiple patients with the same specified `ATTRIBUTE`, the sort will preserve the original order 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -430,7 +430,7 @@ Sorts the patient list in the address book by specified attribute.
 
 Format: `sort [ATTRIBUTE]`
 
-* Sorts all the added patients in the patient list by specified `ATTRIBUTE`.
+* Sorts all the existing patients in the patient list by specified `ATTRIBUTE`.
 * Supported `ATTRIBUTE`s include `n` for patient name and `p` for patient's preferred name.
 * There can only be one or zero `ATTRIBUTE`.
 * If no `ATTRIBUTE` is specified, default sorting order would be by patient's name.


### PR DESCRIPTION
Update typo in specification of sort command. `ATTRIBUTES` -> `ATTRIBUTE`s to be consistent throughout